### PR TITLE
Fix spelling error in Gradio guide: `straightrward` to `straightforward`

### DIFF
--- a/guides/08_gradio-clients-and-lite/05_gradio-lite.md
+++ b/guides/08_gradio-clients-and-lite/05_gradio-lite.md
@@ -89,7 +89,7 @@ What if you want to create a Gradio app that spans multiple files? Or that has c
 
 ### Multiple Files
 
-Adding multiple files within a `@gradio/lite` app is very straightrward: use the `<gradio-file>` tag. You can have as many `<gradio-file>` tags as you want, but each one needs to have a `name` attribute and the entry point to your Gradio app should have the `entrypoint` attribute.
+Adding multiple files within a `@gradio/lite` app is very straightforward: use the `<gradio-file>` tag. You can have as many `<gradio-file>` tags as you want, but each one needs to have a `name` attribute and the entry point to your Gradio app should have the `entrypoint` attribute.
 
 Here's an example:
 


### PR DESCRIPTION
## Description
This pull request addresses a spelling error found in the Gradio Python guide. The word `straightrward` has been corrected to `straightforward` for accuracy and clarity. 





